### PR TITLE
Cd to default-directory before running git diff

### DIFF
--- a/git-command.el
+++ b/git-command.el
@@ -83,8 +83,10 @@
   '(("diff" . (lambda (options cmd args new-buffer-p)
                 (let ((buf (if new-buffer-p
                                (generate-new-buffer "*git diff*")
-                             (get-buffer-create "*git diff*"))))
+                             (get-buffer-create "*git diff*")))
+                      (dir default-directory))
                   (with-current-buffer buf
+                    (cd dir)
                     (erase-buffer)
                     (shell-command (concat "git "
                                            (git-command-construct-commandline


### PR DESCRIPTION
## 問題点

前回使った diff バッファが存在すると、それを再利用する。そのときに、 `git diff` コマンドをそのバッファで実行すると `default-directory` が古いままなので、想定と違うディレクトリで `git diff` を実行することになる場合ある
## 修正点

`git diff` 実行前に cd する
